### PR TITLE
feat: Improve customer journey and fix demo mode

### DIFF
--- a/app/src/main/java/com/signagepro/app/features/choice/ui/InitialChoiceScreen.kt
+++ b/app/src/main/java/com/signagepro/app/features/choice/ui/InitialChoiceScreen.kt
@@ -1,0 +1,71 @@
+package com.signagepro.app.features.choice.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.signagepro.app.ui.theme.SignageProTVTheme // Assuming this is your app's theme
+
+@Composable
+fun InitialChoiceScreen(
+    onNavigateToRegistration: () -> Unit,
+    onNavigateToDemo: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "Welcome to SignagePro", // Or a similar title
+            style = MaterialTheme.typography.headlineMedium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(bottom = 32.dp)
+        )
+
+        Button(
+            onClick = onNavigateToRegistration,
+            modifier = Modifier
+                .fillMaxWidth(0.7f) // Make button wide but not full width
+                .padding(bottom = 16.dp)
+                .height(56.dp) // Make button taller for TV
+        ) {
+            Text("Register Device", style = MaterialTheme.typography.titleMedium)
+        }
+
+        OutlinedButton( // Or another Button
+            onClick = onNavigateToDemo,
+            modifier = Modifier
+                .fillMaxWidth(0.7f)
+                .height(56.dp)
+        ) {
+            Text("Try Demo Mode", style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}
+
+@Preview(showBackground = true, device = "id:tv_1080p") // Preview for TV
+@Composable
+fun PreviewInitialChoiceScreen() {
+    SignageProTVTheme {
+        InitialChoiceScreen(
+            onNavigateToRegistration = {},
+            onNavigateToDemo = {}
+        )
+    }
+}

--- a/app/src/main/java/com/signagepro/app/features/demo/ui/DemoScreen.kt
+++ b/app/src/main/java/com/signagepro/app/features/demo/ui/DemoScreen.kt
@@ -1,1 +1,32 @@
- 
+package com.signagepro.app.features.demo.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.signagepro.app.ui.theme.SignageProTVTheme
+
+@Composable
+fun DemoScreen() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Demo Mode",
+            style = MaterialTheme.typography.headlineLarge
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewDemoScreen() {
+    SignageProTVTheme {
+        DemoScreen()
+    }
+}

--- a/app/src/main/java/com/signagepro/app/features/registration/ui/RegistrationScreen.kt
+++ b/app/src/main/java/com/signagepro/app/features/registration/ui/RegistrationScreen.kt
@@ -19,7 +19,6 @@ import com.signagepro.app.features.registration.viewmodel.RegistrationViewModel
 fun RegistrationScreen(
     viewModel: RegistrationViewModel,
     onRegistrationSuccess: () -> Unit,
-    onSkipToDemo: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var tenantId by remember { mutableStateOf("") }
@@ -118,23 +117,6 @@ fun RegistrationScreen(
                         viewModel.registerDevice(tenantId, hardwareId)
                     },
                     isLoading = viewModel.registrationState is RegistrationState.Loading
-                )
-
-                Divider(
-                    modifier = Modifier.padding(vertical = 16.dp),
-                    color = MaterialTheme.colorScheme.outlineVariant
-                )
-
-                Text(
-                    text = "Want to try before registering?",
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.fillMaxWidth()
-                )
-
-                SignageProOutlinedButton(
-                    text = "Try Demo Mode",
-                    onClick = onSkipToDemo
                 )
             }
         }

--- a/app/src/main/java/com/signagepro/app/features/splash/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/com/signagepro/app/features/splash/viewmodel/SplashViewModel.kt
@@ -15,6 +15,7 @@ sealed class SplashDestination {
     object Registration : SplashDestination()
     object Onboarding : SplashDestination()
     object Display : SplashDestination()
+    object InitialChoice : SplashDestination() // New line
     object Undetermined : SplashDestination()
 }
 
@@ -32,13 +33,13 @@ class SplashViewModel @Inject constructor(
             try {
                 val isRegistered = deviceRepository.isDeviceRegistered()
                 _navigateTo.value = when {
-                    !isRegistered -> SplashDestination.Registration
+                    !isRegistered -> SplashDestination.InitialChoice // Changed line
                     shouldShowOnboarding() -> SplashDestination.Onboarding
                     else -> SplashDestination.Display
                 }
             } catch (e: Exception) {
-                // If there's an error checking registration, default to registration flow
-                _navigateTo.value = SplashDestination.Registration
+                // If there's an error checking registration, default to initial choice flow
+                _navigateTo.value = SplashDestination.InitialChoice // Changed line
             }
         }
     }

--- a/app/src/main/java/com/signagepro/app/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/signagepro/app/ui/navigation/AppNavigation.kt
@@ -35,6 +35,8 @@ import com.signagepro.app.features.device.viewmodel.DeviceInfoViewModel
 import com.signagepro.app.features.network.ui.NetworkSettingsScreen
 import com.signagepro.app.features.network.viewmodel.NetworkSettingsViewModel
 import com.signagepro.app.features.onboarding.ui.OnboardingScreen
+import com.signagepro.app.features.demo.ui.DemoScreen // Added import
+import com.signagepro.app.features.choice.ui.InitialChoiceScreen // New import
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
@@ -62,6 +64,11 @@ fun AppNavigation(
 
             LaunchedEffect(splashDestination) {
                 when (splashDestination) {
+                    SplashDestination.InitialChoice -> { // New case
+                        navController.navigate(Screen.InitialChoice.route) {
+                            popUpTo(Screen.Splash.route) { inclusive = true }
+                        }
+                    }
                     SplashDestination.Registration -> {
                         navController.navigate(Screen.Registration.route) {
                             popUpTo(Screen.Splash.route) { inclusive = true }
@@ -97,14 +104,6 @@ fun AppNavigation(
                     // when registration is successful. We'll navigate from here.
                     navController.navigate(createDisplayRoute("default_layout")) {
                         popUpTo(Screen.Registration.route) { inclusive = true }
-                    }
-                },
-                onSkipToDemo = {
-                    // TODO: Implement actual navigation to a Demo Screen or demo mode
-                    // For now, let's navigate to a hypothetical "Demo" route
-                    // You might want to create a Screen.Demo route and a DemoScreen composable
-                    navController.navigate("demo_screen_route") { // Replace with actual demo route
-                         popUpTo(Screen.Registration.route) { inclusive = true }
                     }
                 }
             )
@@ -167,6 +166,25 @@ fun AppNavigation(
         composable(Screen.NetworkSettings.route) {
             val networkSettingsViewModel: NetworkSettingsViewModel = hiltViewModel()
             NetworkSettingsScreen(viewModel = networkSettingsViewModel)
+        }
+
+        composable(Screen.Demo.route) { // Added DemoScreen composable
+            DemoScreen()
+        }
+
+        composable(Screen.InitialChoice.route) { // New composable
+            InitialChoiceScreen(
+                onNavigateToRegistration = {
+                    navController.navigate(Screen.Registration.route) {
+                        popUpTo(Screen.InitialChoice.route) { inclusive = true }
+                    }
+                },
+                onNavigateToDemo = {
+                    navController.navigate(Screen.Demo.route) {
+                        popUpTo(Screen.InitialChoice.route) { inclusive = true }
+                    }
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/signagepro/app/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/signagepro/app/ui/navigation/Screen.kt
@@ -13,6 +13,8 @@ sealed class Screen(val route: String) {
     object LayoutEditor : Screen("layout_editor")
     object DeviceInfo : Screen("device_info")
     object NetworkSettings : Screen("network_settings")
+    object Demo : Screen("demo_screen")
+    object InitialChoice : Screen("initial_choice_screen") // Added line
     
     // You can add more screens as needed for your application
     // For example:


### PR DESCRIPTION
This commit introduces several enhancements to the initial user experience:

1.  **Fix "Skip to Demo":** The "Skip to Demo" functionality, previously broken, now correctly navigates to a dedicated demo screen.

2.  **Initial Choice Screen:** A new screen has been added that prompts you to either "Register Device" or "Try Demo Mode" before proceeding to the registration form. This provides a clearer initial path.

3.  **New Demo Screen:** A placeholder `DemoScreen` composable and its corresponding navigation route (`demo_screen`) have been created.

4.  **Updated Navigation Logic:**
    - `SplashViewModel` now directs new users to the `InitialChoiceScreen`.
    - `AppNavigation` has been updated to include routes and composables for `InitialChoiceScreen` and `DemoScreen`.
    - The `onSkipToDemo` callback and UI elements have been removed from the `RegistrationScreen` as this choice is now handled earlier.

5.  **Route Definitions:** New routes for `InitialChoiceScreen` and `DemoScreen` have been added to `Screen.kt`.

These changes address the issue of the broken "skip to demo" feature and provide a more intuitive onboarding flow for users of the Android TV application.